### PR TITLE
fix: add beta websocket redaction controls

### DIFF
--- a/internal/admin/api_settings.go
+++ b/internal/admin/api_settings.go
@@ -11,7 +11,20 @@ import (
 )
 
 type SettingsResponse struct {
-	Lang string `json:"lang"`
+	Lang  string               `json:"lang"`
+	Proxy SettingsProxyPayload `json:"proxy"`
+}
+
+type SettingsProxyPayload struct {
+	WebSocketRedactionBeta bool `json:"websocket_redaction_beta"`
+}
+
+type updateSettingsRequest struct {
+	Proxy *updateSettingsProxyRequest `json:"proxy"`
+}
+
+type updateSettingsProxyRequest struct {
+	WebSocketRedactionBeta *bool `json:"websocket_redaction_beta"`
 }
 
 func normalizeLang(lang string) string {
@@ -66,14 +79,53 @@ func (a *Admin) preferredUILang(r *http.Request) string {
 }
 
 func (a *Admin) handleSettings(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
+	switch r.Method {
+	case http.MethodGet:
+		a.getSettings(w, r)
+	case http.MethodPost:
+		if a == nil || a.auth == nil {
+			http.Error(w, "Admin auth not initialized", http.StatusInternalServerError)
+			return
+		}
+		if ok := a.auth.Require(w, r); !ok {
+			return
+		}
+		a.updateSettings(w, r)
+	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
 	}
+}
 
-	resp := SettingsResponse{Lang: a.preferredUILang(r)}
-
+func (a *Admin) getSettings(w http.ResponseWriter, r *http.Request) {
+	c := a.config.Get()
+	resp := SettingsResponse{
+		Lang: a.preferredUILang(r),
+		Proxy: SettingsProxyPayload{
+			WebSocketRedactionBeta: c.Proxy.WebSocketRedactionBeta,
+		},
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (a *Admin) updateSettings(w http.ResponseWriter, r *http.Request) {
+	var req updateSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if req.Proxy == nil || req.Proxy.WebSocketRedactionBeta == nil {
+		http.Error(w, "Missing fields", http.StatusBadRequest)
+		return
+	}
+
+	if err := a.config.Update(func(c *config.Config) {
+		c.Proxy.WebSocketRedactionBeta = *req.Proxy.WebSocketRedactionBeta
+	}); err != nil {
+		http.Error(w, "Failed to update config", http.StatusInternalServerError)
+		return
+	}
+
+	a.getSettings(w, r)
 }

--- a/internal/admin/static/index.html
+++ b/internal/admin/static/index.html
@@ -139,6 +139,10 @@
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z"/></svg>
           <span data-i18n="nav.debug">调试抓包</span>
         </a>
+        <a href="#/settings" class="nav-item flex items-center gap-3 px-4 py-3 rounded-lg text-text" data-page="settings">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317a1 1 0 011.35-.936l.838.363a1 1 0 00.796 0l.838-.363a1 1 0 011.35.936l.08.91a1 1 0 00.49.79l.746.455a1 1 0 01.364 1.35l-.364.838a1 1 0 000 .796l.364.838a1 1 0 01-.364 1.35l-.746.455a1 1 0 00-.49.79l-.08.91a1 1 0 01-1.35.936l-.838-.363a1 1 0 00-.796 0l-.838.363a1 1 0 01-1.35-.936l-.08-.91a1 1 0 00-.49-.79l-.746-.455a1 1 0 01-.364-1.35l.364-.838a1 1 0 000-.796l-.364-.838a1 1 0 01.364-1.35l.746-.455a1 1 0 00.49-.79l.08-.91z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9.75A2.25 2.25 0 1112 14.25A2.25 2.25 0 0112 9.75z"/></svg>
+          <span data-i18n="nav.settings">设置</span>
+        </a>
       </nav>
       <div class="p-4 border-t border-border">
         <div class="flex justify-between items-center mb-2">
@@ -173,6 +177,7 @@ const i18n = {
 	    'nav.certs': '证书管理',
 	    'nav.logs': '调试日志',
 	    'nav.debug': '调试抓包',
+	    'nav.settings': '设置',
 	    'status.running': '运行中',
     'auth.setup.title': '设置管理密码',
     'auth.setup.subtitle': '首次访问管理面板需要设置一个密码，用于保护本机管理端 API。',
@@ -409,6 +414,17 @@ const i18n = {
     'debug.detail.truncated': '已截断',
     'debug.detail.copy': '复制',
     'debug.detail.close': '关闭',
+    'settings.title': '设置',
+    'settings.subtitle': '代理实验功能和运行时开关。',
+    'settings.experimental': '实验功能',
+    'settings.websocket.title': 'WebSocket 脱敏',
+    'settings.websocket.beta': 'Beta',
+    'settings.websocket.desc': '对 WebSocket 文本消息做最佳努力的上行脱敏与下行还原。',
+    'settings.websocket.statusOn': '已开启',
+    'settings.websocket.statusOff': '已关闭',
+    'settings.websocket.hint': '仅处理未压缩的文本消息；二进制帧、控制帧和带压缩扩展的数据帧会自动透传。部分服务端可能仍会因 MITM/TLS 指纹拒绝连接。',
+    'settings.updated': '设置已更新',
+    'settings.updateFailed': '设置更新失败',
     'audit.title': '拦截记录',
     'audit.subtitle': '每次请求是否命中脱敏规则，以及命中的内容（默认仅显示预览）',
     'audit.clear': '清空',
@@ -479,6 +495,7 @@ const i18n = {
 	    'nav.certs': 'Certificates',
 	    'nav.logs': 'Debug Logs',
 	    'nav.debug': 'Packet Capture',
+	    'nav.settings': 'Settings',
 	    'status.running': 'Running',
     'auth.setup.title': 'Set Admin Password',
     'auth.setup.subtitle': 'First-time access requires setting a password to protect the local admin API.',
@@ -715,6 +732,17 @@ const i18n = {
     'debug.detail.truncated': 'Truncated',
     'debug.detail.copy': 'Copy',
     'debug.detail.close': 'Close',
+    'settings.title': 'Settings',
+    'settings.subtitle': 'Proxy experiments and runtime feature flags.',
+    'settings.experimental': 'Experimental',
+    'settings.websocket.title': 'WebSocket Redaction',
+    'settings.websocket.beta': 'Beta',
+    'settings.websocket.desc': 'Best-effort upstream redaction and downstream restore for WebSocket text messages.',
+    'settings.websocket.statusOn': 'Enabled',
+    'settings.websocket.statusOff': 'Disabled',
+    'settings.websocket.hint': 'Only uncompressed text messages are transformed. Binary/control frames and compressed extension frames are passed through. Some servers may still reject MITM/TLS fingerprints.',
+    'settings.updated': 'Settings updated',
+    'settings.updateFailed': 'Failed to update settings',
     'audit.title': 'Audit',
     'audit.subtitle': 'Per-request redaction hits and matched content (preview by default)',
     'audit.clear': 'Clear',
@@ -850,7 +878,7 @@ async function initLang() {
   applyLang(saved || 'zh');
 }
 
-const state = { stats: { proxy: {}, session: {}, requests: {} }, patterns: { keywords: [], regex: [], builtin: [], exclude: [], secret_files: [] }, rule_lists: [], ui: { patterns_tab: 'rule_lists' }, ner: { enabled: false, presidio_url: '', language: 'en', entities: [], min_score: 0 }, sessions: { total: 0, mappings: [] }, certs: { ca: {} }, audit: { redact_log: true, max_events: 200, events: [], persistence: { available: false, enabled: false, path: '', retention: '' } }, logs: { configured_path: '', effective_path: '', exists: false, lines: [], warning: '' }, debug: { status: { enabled: false, max_body_bytes: 1048576, max_events: 50, mask_headers: true, count: 0 }, events: [] } };
+const state = { stats: { proxy: {}, session: {}, requests: {} }, patterns: { keywords: [], regex: [], builtin: [], exclude: [], secret_files: [] }, rule_lists: [], ui: { patterns_tab: 'rule_lists' }, ner: { enabled: false, presidio_url: '', language: 'en', entities: [], min_score: 0 }, sessions: { total: 0, mappings: [] }, certs: { ca: {} }, audit: { redact_log: true, max_events: 200, events: [], persistence: { available: false, enabled: false, path: '', retention: '' } }, logs: { configured_path: '', effective_path: '', exists: false, lines: [], warning: '' }, debug: { status: { enabled: false, max_body_bytes: 1048576, max_events: 50, mask_headers: true, count: 0 }, events: [] }, settings: { proxy: { websocket_redaction_beta: false } } };
 state.auth = { configured: false, authenticated: false, broken: false, broken_error: '' };
 let auditES = null;
 let logsES = null;
@@ -1013,6 +1041,7 @@ function normalizePatterns(p) {
 	  else if (p === 'certs') renderCerts();
 	  else if (p === 'logs') renderLogs();
 	  else if (p === 'debug') renderDebug();
+	  else if (p === 'settings') renderSettings();
 	  else c.innerHTML = '<div class="text-center py-20 text-muted">Page not found</div>';
 	}
 
@@ -2902,6 +2931,77 @@ async function toggleDeterministicPlaceholders(on) {
   } finally {
     sessionsDeterministicBusy = false;
   }
+}
+
+async function loadManagerSettings() {
+  const d = await api.get('/settings');
+  state.settings = {
+    proxy: {
+      websocket_redaction_beta: !!d?.proxy?.websocket_redaction_beta
+    }
+  };
+}
+
+function renderSettingsMeta() {
+  const enabled = !!(state.settings?.proxy?.websocket_redaction_beta);
+  const tag = document.getElementById('settings-ws-tag');
+  const toggle = document.getElementById('settings-ws-toggle');
+  if (tag) {
+    tag.textContent = enabled ? t('settings.websocket.statusOn') : t('settings.websocket.statusOff');
+    tag.className = 'tag ' + (enabled ? 'tag-green' : 'tag-yellow');
+  }
+  if (toggle) toggle.checked = enabled;
+}
+
+let settingsBusy = false;
+async function toggleWebSocketRedactionBeta(on) {
+  if (settingsBusy) return;
+  const prev = !!(state.settings?.proxy?.websocket_redaction_beta);
+  settingsBusy = true;
+  try {
+    const d = await api.post('/settings', { proxy: { websocket_redaction_beta: !!on } });
+    state.settings = {
+      proxy: {
+        websocket_redaction_beta: !!d?.proxy?.websocket_redaction_beta
+      }
+    };
+    renderSettingsMeta();
+    toast(t('settings.updated'));
+  } catch (e) {
+    if (!state.settings) state.settings = { proxy: { websocket_redaction_beta: prev } };
+    if (!state.settings.proxy) state.settings.proxy = { websocket_redaction_beta: prev };
+    state.settings.proxy.websocket_redaction_beta = prev;
+    renderSettingsMeta();
+    toast(t('settings.updateFailed') + ': ' + e.message, 'error');
+  } finally {
+    settingsBusy = false;
+  }
+}
+
+async function renderSettings() {
+  document.getElementById('main-content').innerHTML =
+    '<div class="mb-8"><h2 class="text-2xl font-bold text-text">' + t('settings.title') + '</h2><p class="text-muted mt-1">' + t('settings.subtitle') + '</p></div>' +
+    '<div class="card p-6">' +
+      '<div class="flex items-start justify-between gap-4">' +
+        '<div class="min-w-0">' +
+          '<div class="flex flex-wrap items-center gap-2 mb-2">' +
+            '<h3 class="font-semibold text-text">' + t('settings.websocket.title') + '</h3>' +
+            '<span class="tag tag-yellow">' + t('settings.websocket.beta') + '</span>' +
+            '<span class="tag tag-blue">' + t('settings.experimental') + '</span>' +
+            '<span id="settings-ws-tag" class="tag tag-yellow">' + t('settings.websocket.statusOff') + '</span>' +
+          '</div>' +
+          '<div class="text-sm text-text">' + t('settings.websocket.desc') + '</div>' +
+          '<div class="text-xs text-muted mt-3 max-w-3xl">' + t('settings.websocket.hint') + '</div>' +
+        '</div>' +
+        '<label class="pill-switch shrink-0" title="' + esc(t('settings.websocket.hint')) + '">' +
+          '<input type="checkbox" id="settings-ws-toggle" onchange="toggleWebSocketRedactionBeta(this.checked)">' +
+          '<span class="pill-slider"></span>' +
+        '</label>' +
+      '</div>' +
+    '</div>';
+
+  await loadManagerSettings();
+  renderSettingsMeta();
 }
 
 async function renderCerts() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ type ProxyConfig struct {
 	// - global: MITM for all hosts (default; best for HTTP(S)_PROXY env usage)
 	// - targets: MITM only for enabled hosts in targets (safer; avoids impacting non-target traffic)
 	InterceptMode string `yaml:"intercept_mode"`
+	// WebSocketRedactionBeta enables best-effort WebSocket text-message redaction/restore.
+	// It is intentionally off by default because some servers/extensions may be incompatible.
+	WebSocketRedactionBeta bool `yaml:"websocket_redaction_beta"`
 }
 
 // PatternsConfig holds pattern matching configuration
@@ -145,9 +148,10 @@ type AuditDBConfig struct {
 // Default configuration values
 var defaultConfig = Config{
 	Proxy: ProxyConfig{
-		Listen:            "127.0.0.1:28657",
-		PlaceholderPrefix: "__VG_",
-		InterceptMode:     "global",
+		Listen:                 "127.0.0.1:28657",
+		PlaceholderPrefix:      "__VG_",
+		InterceptMode:          "global",
+		WebSocketRedactionBeta: false,
 	},
 	Patterns: PatternsConfig{
 		Keywords:    []KeywordPattern{},
@@ -800,6 +804,9 @@ func mergeConfigs(global, project Config) Config {
 	}
 	if project.Proxy.InterceptMode != "" {
 		result.Proxy.InterceptMode = project.Proxy.InterceptMode
+	}
+	if project.Proxy.WebSocketRedactionBeta {
+		result.Proxy.WebSocketRedactionBeta = true
 	}
 	if project.Session.TTL != "" {
 		result.Session.TTL = project.Session.TTL

--- a/internal/pii_next/pipeline/pipeline.go
+++ b/internal/pii_next/pipeline/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"github.com/inkdust2021/vibeguard/internal/pii_next/recognizer"
 	"github.com/inkdust2021/vibeguard/internal/redact"
 	"github.com/inkdust2021/vibeguard/internal/session"
+	"github.com/inkdust2021/vibeguard/internal/textsafe"
 )
 
 // Pipeline merges hits from multiple Recognizers and performs unified replacement.
@@ -55,22 +56,34 @@ func (p *Pipeline) RedactWithMatches(input []byte) ([]byte, []redact.Match) {
 		return append([]byte(nil), input...), nil
 	}
 
-	raw := p.reg.RecognizeAll(input)
-	cands := make([]recognizer.Match, 0, len(raw))
-	for _, m := range raw {
-		if m.Start < 0 || m.End < 0 || m.Start >= m.End || m.End > len(input) {
+	cands := make([]recognizer.Match, 0, 16)
+	for _, span := range textsafe.RedactableSpans(input) {
+		segment := input[span.Start:span.End]
+		if len(segment) == 0 {
 			continue
 		}
-		if m.Category == "" {
-			continue
-		}
-		if p.exclude != nil {
-			original := string(input[m.Start:m.End])
-			if _, ok := p.exclude[original]; ok {
+
+		raw := p.reg.RecognizeAll(segment)
+		for _, m := range raw {
+			globalStart := span.Start + m.Start
+			globalEnd := span.Start + m.End
+			if globalStart < 0 || globalEnd < 0 || globalStart >= globalEnd || globalEnd > len(input) {
 				continue
 			}
+			if m.Category == "" {
+				continue
+			}
+			if p.exclude != nil {
+				original := string(input[globalStart:globalEnd])
+				if _, ok := p.exclude[original]; ok {
+					continue
+				}
+			}
+
+			m.Start = globalStart
+			m.End = globalEnd
+			cands = append(cands, m)
 		}
-		cands = append(cands, m)
 	}
 	if len(cands) == 0 {
 		return append([]byte(nil), input...), nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -38,6 +38,7 @@ import (
 	"github.com/inkdust2021/vibeguard/internal/secretsources"
 	"github.com/inkdust2021/vibeguard/internal/session"
 	"github.com/inkdust2021/vibeguard/internal/stream"
+	"github.com/inkdust2021/vibeguard/internal/wsproxy"
 	"github.com/inkdust2021/vibeguard/internal/zstd"
 )
 
@@ -50,10 +51,11 @@ const (
 var errUnsupportedContentEncoding = errors.New("unsupported content-encoding")
 
 type runtimeConfig struct {
-	interceptMode string
-	targets       map[string]bool
-	redactEng     redact.Redactor
-	restoreEng    *restore.Engine
+	interceptMode          string
+	targets                map[string]bool
+	redactEng              redact.Redactor
+	restoreEng             *restore.Engine
+	websocketRedactionBeta bool
 }
 
 // Server represents the MITM proxy server
@@ -73,6 +75,18 @@ type Server struct {
 type auditCtx struct {
 	id       int64
 	redacted bool
+}
+
+type readWriteCloserAdapter struct {
+	io.ReadCloser
+	writer io.Writer
+}
+
+func (a *readWriteCloserAdapter) Write(p []byte) (int, error) {
+	if a == nil || a.writer == nil {
+		return 0, io.ErrClosedPipe
+	}
+	return a.writer.Write(p)
 }
 
 // NewServer creates a new proxy server
@@ -228,6 +242,32 @@ func requestHost(req *http.Request) string {
 		}
 	}
 	return canonicalHost(req.Host)
+}
+
+func isWebSocketUpgradeRequest(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	if !headerContainsToken(req.Header, "Connection", "upgrade") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(req.Header.Get("Upgrade")), "websocket")
+}
+
+func headerContainsToken(h http.Header, key, want string) bool {
+	if h == nil {
+		return false
+	}
+	value := h.Get(key)
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
+	for _, part := range strings.Split(value, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), want) {
+			return true
+		}
+	}
+	return false
 }
 
 func safeRequestPath(req *http.Request) string {
@@ -694,6 +734,15 @@ func (s *Server) setupHandlers() {
 			return req, nil // Pass through
 		}
 
+		// WebSocket 握手对协议头和连接升级流程更敏感，这里保持透传，
+		// 避免通用 HTTP 文本处理逻辑误改握手请求。
+		if isWebSocketUpgradeRequest(req) {
+			auditEv.Attempted = false
+			auditEv.Note = "websocket_upgrade"
+			recordAudit()
+			return req, nil
+		}
+
 		dbg := s.admin.Debug()
 		dbgOn := dbg != nil && dbg.Enabled()
 		dbgMaxBody := 0
@@ -950,6 +999,26 @@ func (s *Server) setupHandlers() {
 				ev.ResponseStatus = resp.StatusCode
 				ev.ResponseContentType = contentType
 			})
+		}
+
+		if isWebSocketUpgradeRequest(ctx.Req) && resp.StatusCode == http.StatusSwitchingProtocols {
+			if rt.websocketRedactionBeta {
+				switch rwc := any(resp.Body).(type) {
+				case io.ReadWriteCloser:
+					resp.Body = wsproxy.NewTransformConn(rwc, rt.redactEng, rt.restoreEng)
+				case interface {
+					io.ReadCloser
+					io.Writer
+				}:
+					resp.Body = wsproxy.NewTransformConn(&readWriteCloserAdapter{
+						ReadCloser: rwc,
+						writer:     rwc,
+					}, rt.redactEng, rt.restoreEng)
+				default:
+					slog.Warn("WebSocket redaction beta requested, but upgraded connection is not writable; falling back to pass-through", "host", host)
+				}
+			}
+			return resp
 		}
 
 		// Check for compression (defensive)
@@ -1505,10 +1574,11 @@ func (s *Server) applyConfig(c config.Config) {
 	}
 
 	s.runtime.Store(runtimeConfig{
-		interceptMode: interceptMode,
-		targets:       targets,
-		redactEng:     redactor,
-		restoreEng:    restore.NewEngine(s.session, prefix),
+		interceptMode:          interceptMode,
+		targets:                targets,
+		redactEng:              redactor,
+		restoreEng:             restore.NewEngine(s.session, prefix),
+		websocketRedactionBeta: c.Proxy.WebSocketRedactionBeta,
 	})
 }
 
@@ -1526,6 +1596,7 @@ func (s *Server) ReloadFromConfig() {
 	slog.Info("Config reloaded",
 		"intercept_mode", rt.interceptMode,
 		"targets", len(rt.targets),
+		"websocket_redaction_beta", rt.websocketRedactionBeta,
 		"deterministic_placeholders", c.Session.DeterministicPlaceholders,
 		"keywords", len(c.Patterns.Keywords),
 		"secret_files", len(c.Patterns.SecretFiles),

--- a/internal/redact/engine.go
+++ b/internal/redact/engine.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inkdust2021/vibeguard/internal/ahocorasick"
 	"github.com/inkdust2021/vibeguard/internal/session"
+	"github.com/inkdust2021/vibeguard/internal/textsafe"
 )
 
 // Match represents a detected sensitive data match
@@ -80,62 +81,77 @@ func (e *Engine) RedactWithMatches(input []byte) ([]byte, []Match) {
 	var matches []Match
 
 	e.ensureKeywordMatcher()
+	spans := textsafe.RedactableSpans(input)
 	if e.kwAC != nil {
 		// Rough estimate: each keyword hits ~0-1 times; preallocation reduces growth.
 		matches = make([]Match, 0, min(len(e.kwCats), 64))
-
-		scratchAny := e.kwScratch.Get()
-		lastEnd, _ := scratchAny.([]int)
-
-		e.kwAC.EachMatchNonOverlappingPerPattern(input, lastEnd, func(id, start, end int) bool {
-			cat := ""
-			if id >= 0 && id < len(e.kwCats) {
-				cat = e.kwCats[id]
-			}
-
-			orig := string(input[start:end])
-			if e.isExcluded(orig) {
-				return true
-			}
-			matches = append(matches, Match{
-				Start:    start,
-				End:      end,
-				Original: orig,
-				Category: cat,
-			})
-			return true
-		})
-
-		if lastEnd != nil {
-			e.kwScratch.Put(lastEnd)
-		}
 	}
 
-	// Regex matching
-	for i, re := range e.regex {
-		locs := re.FindAllSubmatchIndex(input, -1)
-		for _, loc := range locs {
-			if len(loc) < 2 {
-				continue
-			}
+	for _, span := range spans {
+		segment := input[span.Start:span.End]
+		if len(segment) == 0 {
+			continue
+		}
 
-			start, end := loc[0], loc[1]
-			// If capture groups exist, prefer the first capture group's range for redaction replacement.
-			if len(loc) >= 4 && loc[2] >= 0 && loc[3] >= 0 {
-				start, end = loc[2], loc[3]
-			}
-			if start < 0 || end < 0 || start >= end || end > len(input) {
-				continue
-			}
+		if e.kwAC != nil {
+			scratchAny := e.kwScratch.Get()
+			lastEnd, _ := scratchAny.([]int)
 
-			original := string(input[start:end])
-			if !e.isExcluded(original) {
+			e.kwAC.EachMatchNonOverlappingPerPattern(segment, lastEnd, func(id, start, end int) bool {
+				cat := ""
+				if id >= 0 && id < len(e.kwCats) {
+					cat = e.kwCats[id]
+				}
+
+				globalStart := span.Start + start
+				globalEnd := span.Start + end
+				orig := string(input[globalStart:globalEnd])
+				if e.isExcluded(orig) {
+					return true
+				}
 				matches = append(matches, Match{
-					Start:    start,
-					End:      end,
-					Original: original,
-					Category: e.regexCats[i],
+					Start:    globalStart,
+					End:      globalEnd,
+					Original: orig,
+					Category: cat,
 				})
+				return true
+			})
+
+			if lastEnd != nil {
+				e.kwScratch.Put(lastEnd)
+			}
+		}
+
+		// 正则也只在安全文本段内执行，避免把 ANSI/控制字节吞进去。
+		for i, re := range e.regex {
+			locs := re.FindAllSubmatchIndex(segment, -1)
+			for _, loc := range locs {
+				if len(loc) < 2 {
+					continue
+				}
+
+				start, end := loc[0], loc[1]
+				// If capture groups exist, prefer the first capture group's range for redaction replacement.
+				if len(loc) >= 4 && loc[2] >= 0 && loc[3] >= 0 {
+					start, end = loc[2], loc[3]
+				}
+
+				globalStart := span.Start + start
+				globalEnd := span.Start + end
+				if globalStart < 0 || globalEnd < 0 || globalStart >= globalEnd || globalEnd > len(input) {
+					continue
+				}
+
+				original := string(input[globalStart:globalEnd])
+				if !e.isExcluded(original) {
+					matches = append(matches, Match{
+						Start:    globalStart,
+						End:      globalEnd,
+						Original: original,
+						Category: e.regexCats[i],
+					})
+				}
 			}
 		}
 	}

--- a/internal/textsafe/spans.go
+++ b/internal/textsafe/spans.go
@@ -1,0 +1,127 @@
+package textsafe
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Span 表示输入中“允许参与脱敏匹配”的连续字节区间。
+// 控制字符、ANSI 转义序列、零宽/格式字符都会被当作边界跳过。
+type Span struct {
+	Start int
+	End   int
+}
+
+// RedactableSpans 将输入拆成若干安全文本段。
+// 这样可以避免规则跨越终端控制符或 ANSI 样式序列，把格式字节一并替换掉。
+func RedactableSpans(input []byte) []Span {
+	if len(input) == 0 {
+		return nil
+	}
+
+	var spans []Span
+	segStart := -1
+
+	for i := 0; i < len(input); {
+		if n := protectedSeqLen(input[i:]); n > 0 {
+			if segStart >= 0 && segStart < i {
+				spans = append(spans, Span{Start: segStart, End: i})
+			}
+			segStart = -1
+			i += n
+			continue
+		}
+
+		if segStart < 0 {
+			segStart = i
+		}
+
+		_, size := utf8.DecodeRune(input[i:])
+		if size <= 0 {
+			size = 1
+		}
+		i += size
+	}
+
+	if segStart >= 0 && segStart < len(input) {
+		spans = append(spans, Span{Start: segStart, End: len(input)})
+	}
+
+	return spans
+}
+
+func protectedSeqLen(input []byte) int {
+	if len(input) == 0 {
+		return 0
+	}
+
+	if n := ansiEscapeSeqLen(input); n > 0 {
+		return n
+	}
+
+	r, size := utf8.DecodeRune(input)
+	if r == utf8.RuneError && size == 1 {
+		if isASCIITextByte(input[0]) {
+			return 0
+		}
+		return 1
+	}
+
+	if isProtectedRune(r) {
+		return size
+	}
+	return 0
+}
+
+func isASCIITextByte(b byte) bool {
+	switch b {
+	case '\n', '\r', '\t':
+		return true
+	}
+	return b >= 0x20 && b != 0x7f
+}
+
+func isProtectedRune(r rune) bool {
+	switch r {
+	case '\n', '\r', '\t':
+		return false
+	}
+	if r < 0x20 || r == 0x7f {
+		return true
+	}
+	return unicode.Is(unicode.Cc, r) || unicode.Is(unicode.Cf, r)
+}
+
+func ansiEscapeSeqLen(input []byte) int {
+	if len(input) == 0 || input[0] != 0x1b {
+		return 0
+	}
+	if len(input) == 1 {
+		return 1
+	}
+
+	switch input[1] {
+	case '[':
+		// CSI: ESC [ ... final-byte(0x40~0x7E)
+		for i := 2; i < len(input); i++ {
+			if input[i] >= 0x40 && input[i] <= 0x7e {
+				return i + 1
+			}
+		}
+		return len(input)
+	case ']', 'P', 'X', '^', '_':
+		// OSC/DCS/SOS/PM/APC：以 BEL 或 ST(ESC \) 结束。
+		for i := 2; i < len(input); i++ {
+			if input[i] == 0x07 {
+				return i + 1
+			}
+			if input[i] == 0x1b && i+1 < len(input) && input[i+1] == '\\' {
+				return i + 2
+			}
+		}
+		return len(input)
+	default:
+		// 其它两字节 ESC 序列。
+		return 2
+	}
+}

--- a/internal/textsafe/spans_test.go
+++ b/internal/textsafe/spans_test.go
@@ -1,0 +1,38 @@
+package textsafe
+
+import "testing"
+
+func TestRedactableSpansSkipsANSISequences(t *testing.T) {
+	input := []byte("foo\x1b[90mbar\x1b[0mbaz")
+
+	got := RedactableSpans(input)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 spans, got %d", len(got))
+	}
+
+	want := []Span{
+		{Start: 0, End: 3},
+		{Start: 8, End: 11},
+		{Start: 15, End: 18},
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("span %d mismatch: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRedactableSpansSkipsFormatRunes(t *testing.T) {
+	input := []byte("A\u200bB")
+
+	got := RedactableSpans(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(got))
+	}
+	if string(input[got[0].Start:got[0].End]) != "A" {
+		t.Fatalf("unexpected first span: %q", input[got[0].Start:got[0].End])
+	}
+	if string(input[got[1].Start:got[1].End]) != "B" {
+		t.Fatalf("unexpected second span: %q", input[got[1].Start:got[1].End])
+	}
+}

--- a/internal/wsproxy/transform_conn.go
+++ b/internal/wsproxy/transform_conn.go
@@ -1,0 +1,396 @@
+package wsproxy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/inkdust2021/vibeguard/internal/redact"
+	"github.com/inkdust2021/vibeguard/internal/restore"
+)
+
+const (
+	wsOpcodeContinuation = 0x0
+	wsOpcodeText         = 0x1
+	wsOpcodeBinary       = 0x2
+	wsOpcodeClose        = 0x8
+	wsOpcodePing         = 0x9
+	wsOpcodePong         = 0xa
+)
+
+type readTransformFn func([]byte) []byte
+
+// TransformConn 在 WebSocket 升级后的双向连接上做“上行脱敏、下行还原”。
+// 当前实现只处理未压缩的文本消息；控制帧、二进制帧和带 RSV 位的数据帧全部透传。
+type TransformConn struct {
+	conn io.ReadWriteCloser
+
+	readState  *frameTransformer
+	writeState *frameTransformer
+
+	readMu  sync.Mutex
+	writeMu sync.Mutex
+}
+
+func NewTransformConn(conn io.ReadWriteCloser, redactor redact.Redactor, restorer *restore.Engine) *TransformConn {
+	return &TransformConn{
+		conn: conn,
+		readState: newFrameTransformer(false, func(payload []byte) []byte {
+			if restorer == nil {
+				return append([]byte(nil), payload...)
+			}
+			return restorer.Restore(payload)
+		}),
+		writeState: newFrameTransformer(true, func(payload []byte) []byte {
+			if redactor == nil {
+				return append([]byte(nil), payload...)
+			}
+			out, _ := redactor.RedactWithMatches(payload)
+			return out
+		}),
+	}
+}
+
+func (c *TransformConn) Read(p []byte) (int, error) {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+
+	return c.readState.ReadFrom(c.conn, p)
+}
+
+func (c *TransformConn) Write(p []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	return c.writeState.WriteTo(c.conn, p)
+}
+
+func (c *TransformConn) Close() error {
+	return c.conn.Close()
+}
+
+type frameTransformer struct {
+	maskOutput bool
+	transform  readTransformFn
+
+	inBuf  bytes.Buffer
+	outBuf bytes.Buffer
+	tmp    []byte
+
+	msgMode     messageMode
+	msgBuf      bytes.Buffer
+	passthrough bool
+	pendingErr  error
+}
+
+type messageMode int
+
+const (
+	messageModeNone messageMode = iota
+	messageModeBufferText
+	messageModePassthroughText
+	messageModePassthroughBinary
+)
+
+func newFrameTransformer(maskOutput bool, transform readTransformFn) *frameTransformer {
+	return &frameTransformer{
+		maskOutput: maskOutput,
+		transform:  transform,
+		tmp:        make([]byte, 4096),
+	}
+}
+
+func (t *frameTransformer) ReadFrom(src io.Reader, p []byte) (int, error) {
+	for {
+		if t.outBuf.Len() > 0 {
+			return t.outBuf.Read(p)
+		}
+		if t.passthrough {
+			return src.Read(p)
+		}
+		if t.pendingErr != nil {
+			err := t.pendingErr
+			t.pendingErr = nil
+			return 0, err
+		}
+
+		n, err := src.Read(t.tmp)
+		if n > 0 {
+			t.inBuf.Write(t.tmp[:n])
+			if perr := t.processIncoming(); perr != nil {
+				t.outBuf.Write(t.inBuf.Bytes())
+				t.inBuf.Reset()
+				t.msgBuf.Reset()
+				t.msgMode = messageModeNone
+				t.passthrough = true
+			}
+		}
+
+		if t.outBuf.Len() > 0 {
+			if err != nil {
+				t.pendingErr = err
+			}
+			return t.outBuf.Read(p)
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+}
+
+func (t *frameTransformer) WriteTo(dst io.Writer, p []byte) (int, error) {
+	if t.passthrough {
+		n, err := dst.Write(p)
+		if err != nil {
+			return n, err
+		}
+		return len(p), nil
+	}
+
+	t.inBuf.Write(p)
+	if err := t.processIncoming(); err != nil {
+		t.passthrough = true
+		raw := append([]byte(nil), t.inBuf.Bytes()...)
+		t.inBuf.Reset()
+		t.msgBuf.Reset()
+		t.msgMode = messageModeNone
+		if werr := writeAll(dst, raw); werr != nil {
+			return len(p), werr
+		}
+		return len(p), nil
+	}
+
+	if t.outBuf.Len() > 0 {
+		raw := append([]byte(nil), t.outBuf.Bytes()...)
+		t.outBuf.Reset()
+		if err := writeAll(dst, raw); err != nil {
+			return len(p), err
+		}
+	}
+
+	return len(p), nil
+}
+
+func (t *frameTransformer) processIncoming() error {
+	for {
+		frame, ok, err := parseFrame(t.inBuf.Bytes())
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+		t.inBuf.Next(frame.totalLen)
+
+		out, err := t.handleFrame(frame)
+		if err != nil {
+			return err
+		}
+		if len(out) > 0 {
+			t.outBuf.Write(out)
+		}
+	}
+}
+
+func (t *frameTransformer) handleFrame(frame wsFrame) ([]byte, error) {
+	if frame.isControl() {
+		return frame.raw, nil
+	}
+
+	switch frame.opcode {
+	case wsOpcodeText:
+		if frame.rsv != 0 {
+			if !frame.fin {
+				t.msgMode = messageModePassthroughText
+			}
+			return frame.raw, nil
+		}
+		if frame.fin {
+			return t.transformTextMessage(frame.payload)
+		}
+		t.msgBuf.Reset()
+		t.msgBuf.Write(frame.payload)
+		t.msgMode = messageModeBufferText
+		return nil, nil
+
+	case wsOpcodeBinary:
+		if !frame.fin {
+			t.msgMode = messageModePassthroughBinary
+		}
+		return frame.raw, nil
+
+	case wsOpcodeContinuation:
+		switch t.msgMode {
+		case messageModeBufferText:
+			t.msgBuf.Write(frame.payload)
+			if !frame.fin {
+				return nil, nil
+			}
+			payload := append([]byte(nil), t.msgBuf.Bytes()...)
+			t.msgBuf.Reset()
+			t.msgMode = messageModeNone
+			return t.transformTextMessage(payload)
+
+		case messageModePassthroughText, messageModePassthroughBinary:
+			if frame.fin {
+				t.msgMode = messageModeNone
+			}
+			return frame.raw, nil
+
+		default:
+			return frame.raw, nil
+		}
+
+	default:
+		return frame.raw, nil
+	}
+}
+
+func (t *frameTransformer) transformTextMessage(payload []byte) ([]byte, error) {
+	if !utf8.Valid(payload) || t.transform == nil {
+		return buildFrame(true, wsOpcodeText, t.maskOutput, payload)
+	}
+	return buildFrame(true, wsOpcodeText, t.maskOutput, t.transform(payload))
+}
+
+type wsFrame struct {
+	fin      bool
+	rsv      byte
+	opcode   byte
+	masked   bool
+	payload  []byte
+	raw      []byte
+	totalLen int
+}
+
+func (f wsFrame) isControl() bool {
+	return f.opcode >= 0x8
+}
+
+func parseFrame(buf []byte) (wsFrame, bool, error) {
+	var frame wsFrame
+	if len(buf) < 2 {
+		return frame, false, nil
+	}
+
+	b0 := buf[0]
+	b1 := buf[1]
+	frame.fin = b0&0x80 != 0
+	frame.rsv = b0 & 0x70
+	frame.opcode = b0 & 0x0f
+	frame.masked = b1&0x80 != 0
+
+	payloadLen := uint64(b1 & 0x7f)
+	offset := 2
+	switch payloadLen {
+	case 126:
+		if len(buf) < offset+2 {
+			return frame, false, nil
+		}
+		payloadLen = uint64(binary.BigEndian.Uint16(buf[offset : offset+2]))
+		offset += 2
+	case 127:
+		if len(buf) < offset+8 {
+			return frame, false, nil
+		}
+		payloadLen = binary.BigEndian.Uint64(buf[offset : offset+8])
+		offset += 8
+	}
+
+	maskKeyLen := 0
+	if frame.masked {
+		maskKeyLen = 4
+	}
+	total := offset + maskKeyLen
+	if len(buf) < total {
+		return frame, false, nil
+	}
+	if payloadLen > uint64(len(buf)-total) {
+		return frame, false, nil
+	}
+	total += int(payloadLen)
+
+	frame.totalLen = total
+	frame.raw = append([]byte(nil), buf[:total]...)
+
+	payloadOffset := offset
+	var maskKey []byte
+	if frame.masked {
+		maskKey = frame.raw[offset : offset+4]
+		payloadOffset += 4
+	}
+	payload := append([]byte(nil), frame.raw[payloadOffset:total]...)
+	if frame.masked {
+		for i := range payload {
+			payload[i] ^= maskKey[i%4]
+		}
+	}
+	frame.payload = payload
+
+	return frame, true, nil
+}
+
+func buildFrame(fin bool, opcode byte, masked bool, payload []byte) ([]byte, error) {
+	header := make([]byte, 0, 14)
+	b0 := opcode & 0x0f
+	if fin {
+		b0 |= 0x80
+	}
+	header = append(header, b0)
+
+	payloadLen := len(payload)
+	b1 := byte(0)
+	if masked {
+		b1 |= 0x80
+	}
+
+	switch {
+	case payloadLen < 126:
+		header = append(header, b1|byte(payloadLen))
+	case payloadLen <= 65535:
+		header = append(header, b1|126)
+		var ext [2]byte
+		binary.BigEndian.PutUint16(ext[:], uint16(payloadLen))
+		header = append(header, ext[:]...)
+	default:
+		header = append(header, b1|127)
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(payloadLen))
+		header = append(header, ext[:]...)
+	}
+
+	out := make([]byte, 0, len(header)+payloadLen+4)
+	out = append(out, header...)
+
+	if masked {
+		var maskKey [4]byte
+		if _, err := rand.Read(maskKey[:]); err != nil {
+			return nil, err
+		}
+		out = append(out, maskKey[:]...)
+		for i, b := range payload {
+			out = append(out, b^maskKey[i%4])
+		}
+		return out, nil
+	}
+
+	out = append(out, payload...)
+	return out, nil
+}
+
+func writeAll(dst io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := dst.Write(data)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		data = data[n:]
+	}
+	return nil
+}

--- a/internal/wsproxy/transform_conn_test.go
+++ b/internal/wsproxy/transform_conn_test.go
@@ -1,0 +1,101 @@
+package wsproxy
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/inkdust2021/vibeguard/internal/redact"
+	"github.com/inkdust2021/vibeguard/internal/restore"
+	"github.com/inkdust2021/vibeguard/internal/session"
+)
+
+func TestTransformConnWrite_RedactsMaskedTextFrame(t *testing.T) {
+	sess := session.NewManager(time.Minute, 16)
+	t.Cleanup(sess.Close)
+
+	eng := redact.NewEngine(sess, "__VG_")
+	eng.AddKeyword("Alice", "NAME")
+
+	clientSide, upstreamSide := io.Pipe()
+	defer upstreamSide.Close()
+
+	conn := NewTransformConn(pipeReadWriteCloser{Reader: bytes.NewReader(nil), Writer: upstreamSide, closer: io.NopCloser(bytes.NewReader(nil))}, eng, restore.NewEngine(sess, "__VG_"))
+
+	raw, err := buildFrame(true, wsOpcodeText, true, []byte("hello Alice"))
+	if err != nil {
+		t.Fatalf("build frame: %v", err)
+	}
+
+	done := make(chan []byte, 1)
+	go func() {
+		buf, _ := io.ReadAll(clientSide)
+		done <- buf
+	}()
+
+	if n, err := conn.Write(raw); err != nil || n != len(raw) {
+		t.Fatalf("write failed: n=%d err=%v", n, err)
+	}
+	_ = upstreamSide.Close()
+
+	out := <-done
+	frame, ok, err := parseFrame(out)
+	if err != nil || !ok {
+		t.Fatalf("parse output frame failed: ok=%v err=%v", ok, err)
+	}
+	if bytes.Contains(frame.payload, []byte("Alice")) {
+		t.Fatalf("expected Alice to be redacted, got %q", frame.payload)
+	}
+	if !strings.Contains(string(frame.payload), "__VG_NAME_") {
+		t.Fatalf("expected placeholder in payload, got %q", frame.payload)
+	}
+}
+
+func TestTransformConnRead_RestoresTextFrame(t *testing.T) {
+	sess := session.NewManager(time.Minute, 16)
+	t.Cleanup(sess.Close)
+
+	eng := redact.NewEngine(sess, "__VG_")
+	eng.AddKeyword("Alice", "NAME")
+	redacted, _ := eng.RedactWithMatches([]byte("hello Alice"))
+
+	serverFrame, err := buildFrame(true, wsOpcodeText, false, redacted)
+	if err != nil {
+		t.Fatalf("build frame: %v", err)
+	}
+
+	conn := NewTransformConn(pipeReadWriteCloser{
+		Reader: bytes.NewReader(serverFrame),
+		Writer: io.Discard,
+		closer: io.NopCloser(bytes.NewReader(nil)),
+	}, eng, restore.NewEngine(sess, "__VG_"))
+
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	frame, ok, err := parseFrame(buf[:n])
+	if err != nil || !ok {
+		t.Fatalf("parse restored frame failed: ok=%v err=%v", ok, err)
+	}
+	if string(frame.payload) != "hello Alice" {
+		t.Fatalf("expected restored payload, got %q", frame.payload)
+	}
+}
+
+type pipeReadWriteCloser struct {
+	io.Reader
+	io.Writer
+	closer io.Closer
+}
+
+func (p pipeReadWriteCloser) Close() error {
+	if p.closer == nil {
+		return nil
+	}
+	return p.closer.Close()
+}


### PR DESCRIPTION
## Summary
- add a manager settings page with a `WebSocket Redaction (Beta)` toggle
- add best-effort WebSocket text message redaction/restore behind the beta flag
- add text-safe segmentation to avoid replacing ANSI/control characters in terminal output

## Testing
- go test ./internal/textsafe ./internal/redact ./internal/pii_next/pipeline ./internal/wsproxy ./internal/config ./internal/admin ./internal/proxy -count=1 -timeout 60s

Fixes #8